### PR TITLE
typo for local.views fixed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ locals {
   views = toset([
     for view in coalesce(data.snowflake_views.this.views, []) :
     view.name
-    if contains(local.object_types, "table")
+    if contains(local.object_types, "view")
   ])
   stages = toset([
     for stage in coalesce(data.snowflake_stages.this.stages, []) :


### PR DESCRIPTION
When trying to had a privilege of "INSERT", it would fail due to local.view filtering on table